### PR TITLE
Regression test for nil href bug

### DIFF
--- a/spec/services/variables_fetch_service_spec.rb
+++ b/spec/services/variables_fetch_service_spec.rb
@@ -82,10 +82,11 @@ RSpec.describe VariablesFetchService do
       variable = variables.select { |v| v.href.present? && v.description.present? }.sample
 
       # Load all the variables, which should correctly set href and description
-      subject
+      described_class.fetch_all
 
       # Find the corresponding Variable model in the database
       model = Variable.find_by(name: variable.name)
+      expect(model).not_to be_nil
 
       # Check that the database has recorded the correct values from the original data
       expect(model.href).to eq variable.href

--- a/spec/services/variables_fetch_service_spec.rb
+++ b/spec/services/variables_fetch_service_spec.rb
@@ -51,10 +51,11 @@ RSpec.describe VariablesFetchService do
       # overwritten by nil during the .fetch call. This could also have applied
       # to the description (since they are retrieved in the first variables_list
       # call). This is a regression test to ensure the values aren't lost again
-      # in future if the server responses or our code change. Note that this
-      # test isn't very useful if the OpenFisca responses are mocked above.
-      # Consider running this agains the live server to debug weird server
-      # behaviour.
+      # in future if the server responses or our code change. 
+      #
+      # Note that this test isn't very useful if the OpenFisca responses are
+      # mocked above. Consider running this against the live server to debug
+      # weird server behaviour.
 
       # Pick a random Variable where href and description are set
       variable = variables.select { |v| v.href.present? && v.description.present? }.sample


### PR DESCRIPTION
closes #5

This is a quick regression test for a bug which is already fixed. It's mostly a formality but I think it's worth including because the two properties tested here are loaded in a different way from the other Variable properties so there's a higher chance of them getting lost somehow.