### PR TITLE
Set more values in percy spec, to create no differences each run

### DIFF
--- a/app/views/variables/_badges.haml
+++ b/app/views/variables/_badges.haml
@@ -4,7 +4,7 @@
 
   %span.badge.badge-secondary=variable.value_type.name
 
-  %span.badge.badge-secondary=t variable.spec['definitionPeriod']
+  %span.badge.badge-secondary= variable.spec['definitionPeriod']
 
   - if variable.entity.present?
     %span.badge.badge-success= link_to t(variable.entity.name), variable.entity

--- a/spec/factories/variables.rb
+++ b/spec/factories/variables.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     sequence(:name) { |n| "#{Faker::Lorem.word}_#{n}" }
     description { Faker::Lorem.paragraph }
     href { Faker::Internet.url }
-    spec { '{}' }
+    spec { '{"definitionPeriod": "MONTH"}' }
     created_at { DateTime.now.utc }
     updated_at { DateTime.now.utc }
     namespace { Faker::Lorem.word }
-    value_type
+    value_type { FactoryBot.create :value_type, name: 'int' }
     entity
     references { [] }
     unit { nil }

--- a/spec/features/percy_spec.rb
+++ b/spec/features/percy_spec.rb
@@ -15,11 +15,15 @@ describe 'Test with visual testing', type: :feature, js: true do
   end
   before do
     FactoryBot.create :variable,
-                      name: 'first_variable', entity: person, description: 'this one was first',
+                      name: 'first_variable',
+                      entity: person,
+                      description: 'this one was first',
                       namespace: 'humans',
                       value_type: value_type
     FactoryBot.create :variable,
-                      name: 'second_variable', entity: person, description: 'and this one was second',
+                      name: 'second_variable',
+                      entity: person,
+                      description: 'and this one was second',
                       namespace: 'humans',
                       value_type: value_type
   end

--- a/spec/features/percy_spec.rb
+++ b/spec/features/percy_spec.rb
@@ -10,6 +10,7 @@ describe 'Test with visual testing', type: :feature, js: true do
     FactoryBot.create :variable, entity: person,
       name: 'is_eligible_for_chocolate',
       description: 'is eligible for chocolate',
+      namespace: 'chocolate',
       value_type: value_type
   end
   before do

--- a/spec/features/percy_spec.rb
+++ b/spec/features/percy_spec.rb
@@ -4,24 +4,34 @@ require 'rails_helper'
 require 'percy'
 
 describe 'Test with visual testing', type: :feature, js: true do
-  let!(:person) { FactoryBot.create :entity, name: 'person', description: 'this is a human being' }
-  let(:variable) { FactoryBot.create :variable, entity: person, name: 'is_eligible_for_chocolate', description: 'is eligible for chocolate'}
+  let(:value_type) { FactoryBot.create :value_type, name: 'int' }
+  let!(:person) { FactoryBot.create :entity, name: 'person', documentation: 'this is a human being' }
+  let(:variable) do
+    FactoryBot.create :variable, entity: person,
+      name: 'is_eligible_for_chocolate',
+      description: 'is eligible for chocolate',
+      value_type: value_type
+  end
   before do
     FactoryBot.create :variable,
-      name: 'first_variable', entity: person, description: 'this one was first'
+      name: 'first_variable', entity: person, description: 'this one was first',
+        namespace: 'humans',
+        value_type: value_type
     FactoryBot.create :variable,
-      name: 'second_variable', entity: person, description: 'and this one was second'
+      name: 'second_variable', entity: person, description: 'and this one was second',
+        namespace: 'humans',
+        value_type: value_type
   end
   it 'loads homepage' do
     visit root_path
-    Percy.snapshot(page)
+    Percy.snapshot(page, name: 'homepage')
   end
   it 'variables#index' do
     visit variables_path
-    Percy.snapshot(page)
+    Percy.snapshot(page, name: 'variables#index')
   end
   it 'variables#show' do
     visit variable_path(variable)
-    Percy.snapshot(page)
+    Percy.snapshot(page, name: 'variables#show')
   end
 end

--- a/spec/features/percy_spec.rb
+++ b/spec/features/percy_spec.rb
@@ -8,20 +8,20 @@ describe 'Test with visual testing', type: :feature, js: true do
   let!(:person) { FactoryBot.create :entity, name: 'person', documentation: 'this is a human being' }
   let(:variable) do
     FactoryBot.create :variable, entity: person,
-      name: 'is_eligible_for_chocolate',
-      description: 'is eligible for chocolate',
-      namespace: 'chocolate',
-      value_type: value_type
+                                 name: 'is_eligible_for_chocolate',
+                                 description: 'is eligible for chocolate',
+                                 namespace: 'chocolate',
+                                 value_type: value_type
   end
   before do
     FactoryBot.create :variable,
-      name: 'first_variable', entity: person, description: 'this one was first',
-        namespace: 'humans',
-        value_type: value_type
+                      name: 'first_variable', entity: person, description: 'this one was first',
+                      namespace: 'humans',
+                      value_type: value_type
     FactoryBot.create :variable,
-      name: 'second_variable', entity: person, description: 'and this one was second',
-        namespace: 'humans',
-        value_type: value_type
+                      name: 'second_variable', entity: person, description: 'and this one was second',
+                      namespace: 'humans',
+                      value_type: value_type
   end
   it 'loads homepage' do
     visit root_path


### PR DESCRIPTION
The values that factorybot gets from faker gem cause the screenshots compared by percy to be different on every run.
So, instead let's set those values, so they are the same for each percy spec run.
