### PR TITLE
stop long urls from breaking mobile layout

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2,6 +2,7 @@
 
 body {
   margin: 0;
+  word-wrap: break-word;
 }
 
 main {


### PR DESCRIPTION
wraps the urls so they arent sitting outside of view