### PR TITLE
Entities - Match design

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,16 +17,16 @@
 
 // Custom bootstrap variables must be set or imported *before* bootstrap.
 // @import 'bootstrap';
-@import "bootstrap-custom";
-@import "variables";
-@import "layout";
-@import "header";
-@import "buttons";
-@import "cards";
-@import "badges";
-@import "nav";
-@import "sections";
-@import "lists";
-@import "filters";
-@import "headings";
-@import "themes";
+@import 'bootstrap-custom';
+@import 'variables';
+@import 'layout';
+@import 'header';
+@import 'buttons';
+@import 'cards';
+@import 'badges';
+@import 'nav';
+@import 'sections';
+@import 'lists';
+@import 'filters';
+@import 'headings';
+@import 'themes';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,4 @@
 @import "lists";
 @import "filters";
 @import "headings";
+@import "themes";

--- a/app/assets/stylesheets/headings.scss
+++ b/app/assets/stylesheets/headings.scss
@@ -6,3 +6,5 @@
   font-weight: bold;
   margin: 1.25rem 0;
 }
+
+.sub-heading { font-size: 1.6rem; }

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -1,0 +1,38 @@
+@import "variables";
+
+.theme-primary {
+
+  #roles { margin-top: 2rem; }
+
+  #variables { margin-top: 2.5rem; }
+
+  p,
+  .page-heading,
+  .sub-heading { color: $primary-color; }
+
+  .page-heading,
+  .sub-heading { font-weight: bold; }
+
+  p { overflow: auto; }
+
+  .page-heading {
+    font-size: 3rem;
+    margin-top: 0;
+  }
+
+  .sub-heading { margin-bottom: 1rem; }
+
+  .card {
+    border: none;
+    box-shadow: none;
+  }
+
+  .card-body {
+    &--alt {
+      border: 5px solid darken($grey, 20%);
+      border-radius: 0;
+    }
+  }
+
+  .badge-alt { color: $white; }
+}

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -23,7 +23,7 @@
   .sub-heading { margin-bottom: 1rem; }
 
   .card {
-    border: none;
+    border: 0;
     box-shadow: none;
   }
 

--- a/app/views/entities/_badges.html.haml
+++ b/app/views/entities/_badges.html.haml
@@ -1,5 +1,5 @@
 - if entity.variables.size.positive?
-  %span.badge.badge-dark #{pluralize entity.variables.size, 'variable'}
+  %span.badge.badge-alt #{pluralize entity.variables.size, 'variable'}
 
 - if entity.roles.size.positive?
-  %span.badge.badge-dark #{pluralize entity.roles.size, 'role'}
+  %span.badge.badge-alt #{pluralize entity.roles.size, 'role'}

--- a/app/views/entities/index.html.haml
+++ b/app/views/entities/index.html.haml
@@ -1,25 +1,16 @@
--# .container
--#   .card-columns
--#     - @entities.each do |entity|
--#       .card.w-33
--#         .card-body
--#           %h5.card-title
--#             = link_to entity.to_s.capitalize, entity
--#           = render 'badges', entity: entity
--#           %p.card-text
--#             = render_markdown(entity.documentation) if entity.documentation.present?
--#           %h5= t(:example_variables)
--#           %ul.list-group.list-group-flush
--#             - entity.variables.limit(5).order("RANDOM()").each do |v|
--#               %li.list-group-item
--#                 = t v.namespace
--#                 = link_to v.description, v
-%main
-  .container
-    .row
-      .col-lg-3
-        = render 'partials/sidebar'
-      .col-lg-9
-        %section.section
-          - @entities.each do |entity|
-            %h1.heading= link_to entity.to_s.capitalize, entity
+.container
+  .card-columns
+    - @entities.each do |entity|
+      .card.w-33
+        .card-body
+          %h5.card-title
+            = link_to entity.to_s.capitalize, entity
+          = render 'badges', entity: entity
+          %p.card-text
+            = render_markdown(entity.documentation) if entity.documentation.present?
+          %h5= t(:example_variables)
+          %ul.list-group.list-group-flush
+            - entity.variables.limit(5).order("RANDOM()").each do |v|
+              %li.list-group-item
+                = t v.namespace
+                = link_to v.description, v

--- a/app/views/entities/index.html.haml
+++ b/app/views/entities/index.html.haml
@@ -1,16 +1,25 @@
-.container
-  .card-columns
-    - @entities.each do |entity|
-      .card.w-33
-        .card-body
-          %h5.card-title
-            = link_to entity.to_s.capitalize, entity
-          = render 'badges', entity: entity
-          %p.card-text
-            = render_markdown(entity.documentation) if entity.documentation.present?
-          %h5= t(:example_variables)
-          %ul.list-group.list-group-flush
-            - entity.variables.limit(5).order("RANDOM()").each do |v|
-              %li.list-group-item
-                = t v.namespace
-                = link_to v.description, v
+-# .container
+-#   .card-columns
+-#     - @entities.each do |entity|
+-#       .card.w-33
+-#         .card-body
+-#           %h5.card-title
+-#             = link_to entity.to_s.capitalize, entity
+-#           = render 'badges', entity: entity
+-#           %p.card-text
+-#             = render_markdown(entity.documentation) if entity.documentation.present?
+-#           %h5= t(:example_variables)
+-#           %ul.list-group.list-group-flush
+-#             - entity.variables.limit(5).order("RANDOM()").each do |v|
+-#               %li.list-group-item
+-#                 = t v.namespace
+-#                 = link_to v.description, v
+%main
+  .container
+    .row
+      .col-lg-3
+        = render 'partials/sidebar'
+      .col-lg-9
+        %section.section
+          - @entities.each do |entity|
+            %h1.heading= link_to entity.to_s.capitalize, entity

--- a/app/views/entities/show.html.haml
+++ b/app/views/entities/show.html.haml
@@ -1,28 +1,3 @@
--# .container
--#   %h1= @entity.description
--#   = render 'badges', entity: @entity
-
-  -# %p
-  -#   = render_markdown(@entity.documentation) if @entity.documentation.present?
-
-
-  -# - if @entity.roles.size.positive?
-  -#   %h2 Roles within #{@entity.description}
-
-  -#   .card-columns
-  -#     - @entity.roles.each do |role|
-  -#       .card{:style => "width: 18rem;"}
-  -#         .card-body
-  -#           %h5.card-title= role.name
-  -#           %p.card-text= role.description
-
-
-  -# %h3.page-heading= t(:variables_that_you_can_set, entity_description: @entity.description)
-
-  -# .card-columns
-  -#   - @entity.variables.order(:namespace, :name).each do |variable|
-  -#     = render 'variables/card', variable: variable
-
 %main
   .container
     .row

--- a/app/views/entities/show.html.haml
+++ b/app/views/entities/show.html.haml
@@ -28,27 +28,28 @@
     .row
       .col-lg-3
         = render 'partials/sidebar', title: @entity.description
+
       .col-lg-9
-        %h1= @entity.description
-        = render 'badges', entity: @entity
+        %section.section.theme-primary
+          #about
+            %h1.page-heading= @entity.description
+            = render 'badges', entity: @entity
 
-        %p
-          = render_markdown(@entity.documentation) if @entity.documentation.present?
+            %p= render_markdown(@entity.documentation) if @entity.documentation.present?
 
+          #roles
+            - if @entity.roles.size.positive?
+              %h2.sub-heading Roles within #{@entity.description}
 
-        - if @entity.roles.size.positive?
-          %h2 Roles within #{@entity.description}
+              .card-columns
+                - @entity.roles.each do |role|
+                  .card
+                    .card-body.card-body--alt
+                      %h5.card-title= role.name
+                      %p.card-text= role.description
 
-          .card-columns
-            - @entity.roles.each do |role|
-              .card{:style => "width: 18rem;"}
-                .card-body
-                  %h5.card-title= role.name
-                  %p.card-text= role.description
+          #variables
+            %h3.sub-heading= t(:variables_that_you_can_set, entity_description: @entity.description)
 
-
-        %h3.page-heading= t(:variables_that_you_can_set, entity_description: @entity.description)
-
-        .card-columns
-          - @entity.variables.order(:namespace, :name).each do |variable|
-            = render 'variables/card', variable: variable
+            - @entity.variables.order(:namespace, :name).each do |variable|
+              = render 'variables/list', variable: variable

--- a/app/views/entities/show.html.haml
+++ b/app/views/entities/show.html.haml
@@ -1,24 +1,54 @@
-.container
-  %h1= @entity.description
-  = render 'badges', entity: @entity
+-# .container
+-#   %h1= @entity.description
+-#   = render 'badges', entity: @entity
 
-  %p
-    = render_markdown(@entity.documentation) if @entity.documentation.present?
-
-
-  - if @entity.roles.size.positive?
-    %h2 Roles within #{@entity.description}
-
-    .card-columns
-      - @entity.roles.each do |role|
-        .card{:style => "width: 18rem;"}
-          .card-body
-            %h5.card-title= role.name
-            %p.card-text= role.description
+  -# %p
+  -#   = render_markdown(@entity.documentation) if @entity.documentation.present?
 
 
-  %h3.page-heading= t(:variables_that_you_can_set, entity_description: @entity.description)
+  -# - if @entity.roles.size.positive?
+  -#   %h2 Roles within #{@entity.description}
 
-  .card-columns
-    - @entity.variables.order(:namespace, :name).each do |variable|
-      = render 'variables/card', variable: variable
+  -#   .card-columns
+  -#     - @entity.roles.each do |role|
+  -#       .card{:style => "width: 18rem;"}
+  -#         .card-body
+  -#           %h5.card-title= role.name
+  -#           %p.card-text= role.description
+
+
+  -# %h3.page-heading= t(:variables_that_you_can_set, entity_description: @entity.description)
+
+  -# .card-columns
+  -#   - @entity.variables.order(:namespace, :name).each do |variable|
+  -#     = render 'variables/card', variable: variable
+
+%main
+  .container
+    .row
+      .col-lg-3
+        = render 'partials/sidebar', title: @entity.description
+      .col-lg-9
+        %h1= @entity.description
+        = render 'badges', entity: @entity
+
+        %p
+          = render_markdown(@entity.documentation) if @entity.documentation.present?
+
+
+        - if @entity.roles.size.positive?
+          %h2 Roles within #{@entity.description}
+
+          .card-columns
+            - @entity.roles.each do |role|
+              .card{:style => "width: 18rem;"}
+                .card-body
+                  %h5.card-title= role.name
+                  %p.card-text= role.description
+
+
+        %h3.page-heading= t(:variables_that_you_can_set, entity_description: @entity.description)
+
+        .card-columns
+          - @entity.variables.order(:namespace, :name).each do |variable|
+            = render 'variables/card', variable: variable

--- a/app/views/partials/_sidebar.html.haml
+++ b/app/views/partials/_sidebar.html.haml
@@ -1,4 +1,4 @@
 %ul.side-nav.list-stripped
-  %li= link_to 'About', ''
-  %li= link_to "Roles within #{title}", ''
-  %li= link_to 'Variables', ''
+  %li= link_to 'About', '#about'
+  %li= link_to "Roles within #{title}", '#roles'
+  %li= link_to 'Variables', '#variables'

--- a/app/views/partials/_sidebar.html.haml
+++ b/app/views/partials/_sidebar.html.haml
@@ -1,6 +1,4 @@
 %ul.side-nav.list-stripped
-  %li= link_to t(:what_is_raputure), '#q1'
-  %li= link_to t(:what_is_legislation_of_code)
-  %li= link_to t(:how_to_use_rapu_ture), '#q3'
-  %li= link_to t(:how_to_contribute)
-  %li= link_to t(:contact_us)
+  %li= link_to 'About', ''
+  %li= link_to "Roles within #{title}", ''
+  %li= link_to 'Variables', ''

--- a/app/views/partials/_sidebar.html.haml
+++ b/app/views/partials/_sidebar.html.haml
@@ -1,0 +1,6 @@
+%ul.side-nav.list-stripped
+  %li= link_to t(:what_is_raputure), '#q1'
+  %li= link_to t(:what_is_legislation_of_code)
+  %li= link_to t(:how_to_use_rapu_ture), '#q3'
+  %li= link_to t(:how_to_contribute)
+  %li= link_to t(:contact_us)

--- a/app/views/variables/_list.haml
+++ b/app/views/variables/_list.haml
@@ -1,0 +1,6 @@
+%ul.list-stripped
+  - cache variable do
+    %li
+      = link_to variable.name, variable
+      %p= variable.description
+      = render 'variables/badges', variable: variable


### PR DESCRIPTION
# What has changed and why?
Changing the page to match design
Wasn't sure what to do with the badges though, any suggestions welcome.

<img width="1156" alt="Screen Shot 2019-05-22 at 2 09 07 PM" src="https://user-images.githubusercontent.com/4723307/58142455-428fb480-7c9b-11e9-9340-b42325271309.png">
<img width="1161" alt="Screen Shot 2019-05-22 at 2 09 16 PM" src="https://user-images.githubusercontent.com/4723307/58142504-6f43cc00-7c9b-11e9-9402-5d2acea7fa4c.png">



# How to test this change

- [ ] test in multiple browsers
- [ ] test in mobile view
- [ ] at least one a reviewer ran the code
