### PR TITLE
the term "orphaned" is ambiguous - changing the label

### DIFF
--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -57,7 +57,7 @@ class Variable < ApplicationRecord
     variables
   end
 
-  def orphaned?
+  def notused?
     inbound_links.empty? && outbound_links.empty?
   end
 end

--- a/app/views/variables/_badges.haml
+++ b/app/views/variables/_badges.haml
@@ -12,10 +12,10 @@
   - if variable.has_formula?
     %span.badge.badge-info= t :formula_included
 
-  - if variable.orphaned?
+  - if variable.notused?
     %span.badge.badge-warning{ 'data-toggle': 'tooltip',
       'data-placement': 'bottom', title: 'Not used by any formula, and has no formula itself' }
-      Orphaned
+      Not used
   - else
     %span.badge.badge-dark used #{pluralize variable.inbound_links.size, 'time'}
 

--- a/spec/controllers/variables_controller_spec.rb
+++ b/spec/controllers/variables_controller_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe VariablesController, type: :controller do
   describe '#index' do
-    context 'one orphaned variable' do
+    context 'one unused variable' do
       let!(:variable) { FactoryBot.create :variable }
       before { get :index }
       it { expect(assigns(:variables)).to eq [variable] }
     end
 
-    context 'three orphaned variables' do
+    context 'three unused variables' do
       let!(:variable) { FactoryBot.create :variable }
       let!(:variable_two) { FactoryBot.create :variable }
       let!(:variable_three) { FactoryBot.create :variable }

--- a/spec/features/variables/index_spec.rb
+++ b/spec/features/variables/index_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 describe 'index' do
-  context 'Variable is orphaned' do
+  context 'Variable is not used' do
     before { FactoryBot.create :variable, name: 'likes_to_eat_chocolate' }
     describe 'view all variables' do
       before { visit variables_path }
       it { expect(page).to have_text 'Available filters for Namespace' }
       it { expect(page).to have_link 'likes_to_eat_chocolate' }
-      it { expect(page).to have_text 'Orphaned' }
+      it { expect(page).to have_text 'Not used' }
     end
   end
 
@@ -24,7 +24,7 @@ describe 'index' do
       it { expect(page).to have_link 'likes_to_eat_chocolate' }
       it { expect(page).to have_link 'likes_to_eat' }
       it { expect(page).to have_text 'used 1 time' }
-      it { expect(page).not_to have_text 'Orphaned' }
+      it { expect(page).not_to have_text 'Not used' }
     end
   end
 end

--- a/spec/features/variables/show_spec.rb
+++ b/spec/features/variables/show_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 describe 'show' do
-  context 'Variable is orphaned' do
+  context 'Variable is not used' do
     let(:variable) { FactoryBot.create :variable, name: 'likes_to_eat_chocolate' }
     describe 'view all variables' do
       before { visit variable_path(variable) }
       it { expect(page).to have_content variable.name }
-      it { expect(page).to have_text 'Orphaned' }
+      it { expect(page).to have_text 'Not used' }
     end
   end
 
@@ -20,7 +20,7 @@ describe 'show' do
       it { expect(page).to have_link parent.name }
       it { expect(page).to have_content child.name }
       it { expect(page).to have_text 'used 1 time' }
-      it { expect(page).not_to have_text 'Orphaned' }
+      it { expect(page).not_to have_text 'Not used' }
     end
   end
 end

--- a/spec/models/variable_spec.rb
+++ b/spec/models/variable_spec.rb
@@ -17,22 +17,22 @@ RSpec.describe Variable, type: :model do
     let(:child1) { FactoryBot.create :variable }
     let(:child2) { FactoryBot.create :variable }
 
-    let(:orphan) { FactoryBot.create :variable }
+    let(:notused) { FactoryBot.create :variable }
 
     it { expect(parent.inbound_links.size).to eq 2 }
     it { expect(parent.outbound_links.size).to eq 0 }
-    it { expect(parent.orphaned?).to be false }
+    it { expect(parent.notused?).to be false }
 
     it { expect(child1.outbound_links.size).to eq 1 }
     it { expect(child1.inbound_links.size).to eq 0 }
-    it { expect(child1.orphaned?).to be false }
+    it { expect(child1.notused?).to be false }
 
     it { expect(child2.outbound_links.size).to eq 1 }
     it { expect(child2.inbound_links.size).to eq 0 }
-    it { expect(child2.orphaned?).to be false }
+    it { expect(child2.notused?).to be false }
 
-    it { expect(orphan.orphaned?).to be true }
-    it { expect(orphan.inbound_links.size).to be 0 }
-    it { expect(orphan.outbound_links.size).to be 0 }
+    it { expect(notused.notused?).to be true }
+    it { expect(notused.inbound_links.size).to be 0 }
+    it { expect(notused.outbound_links.size).to be 0 }
   end
 end


### PR DESCRIPTION
# What has changed and why?
the term "orphaned" is ambiguous - changing the label to not used


- [x] has automated tests
- [ ] at least one a reviewer ran the code


![image](https://user-images.githubusercontent.com/12266/148286248-ff044599-3dfd-49a9-831f-56bff781d591.png)
https://nz.openfisca.org/variables/student_allowance__income_before_tax